### PR TITLE
Fixes Untradeables

### DIFF
--- a/src/main/java/com/creativetechguy/NoBadAlchsPlugin.java
+++ b/src/main/java/com/creativetechguy/NoBadAlchsPlugin.java
@@ -200,8 +200,9 @@ public class NoBadAlchsPlugin extends Plugin {
             int alchPrice = (alchType == AlchType.Low || alchType == AlchType.RingLow) ? (int) (itemPrice * 0.4) : (int) (itemPrice * 0.6);
             int geValue = (int) (itemManager.getItemPrice(inventoryItem.getItemId()) * 0.99); // Account for GE tax
             int minAlchPrice = (int) (geValue * minAlchPriceRatio + alchPriceMargin + runeCost);
+            boolean untradeable = !(itemManager.getItemComposition(inventoryItem.getItemId()).isTradeable());
             boolean shouldHide = false;
-            if (geValue == 0 && config.hideUntradeables()) {
+            if (untradeable && config.hideUntradeables()) {
                 shouldHide = true;
             }
             if (alchPrice <= minAlchPrice) {


### PR DESCRIPTION
## What Does This PR Do
Before, only items with 0 price were untradeable. This didn't work for some things like the trouvered avernic. Now it uses the item flag, which should be more reliable. Fixes #9 

## Testing
I don't have a trouvered avernic, so I can't test the original fault case myself. However, I did confirm that it has the same untradeable flag, and should work with the new system. More testing would not be unwelcome.



